### PR TITLE
Make headings more accessible

### DIFF
--- a/_episodes_rmd/10-data-organisation.Rmd
+++ b/_episodes_rmd/10-data-organisation.Rmd
@@ -19,7 +19,7 @@ keypoints:
 source("../bin/chunk-options.R")
 ```
 
-# Spreadsheet programs
+## Spreadsheet programs
 
 **Question**
 
@@ -41,7 +41,7 @@ spreadsheets. Spreadsheet programs are very useful graphical
 interfaces for designing data tables and handling very basic data
 quality control functions. See also @Broman:2018.
 
-## Spreadsheet outline
+### Spreadsheet outline
 
 Spreadsheets are good for data entry. Therefore we have a lot of data
 in spreadsheets.  Much of your time as a researcher will be spent in
@@ -49,7 +49,7 @@ this 'data wrangling' stage.  It's not the most fun, but it's
 necessary. We'll teach you how to think about data organization and
 some practices for more effective data wrangling.
 
-## What this lesson will not teach you
+### What this lesson will not teach you
 
 - How to do *statistics* in a spreadsheet
 - How to do *plotting* in a spreadsheet
@@ -60,7 +60,7 @@ Excel](https://www.amazon.com/Head-First-Excel-learners-spreadsheets/dp/05968076
 published by O'Reilly.
 
 
-## Why aren't we teaching data analysis in spreadsheets
+### Why aren't we teaching data analysis in spreadsheets
 
 - Data analysis in spreadsheets usually requires a lot of manual
   work. If you want to change a parameter or run an analysis with a
@@ -101,7 +101,7 @@ ensure efficient downstream analysis.
 >   frustrated or sad?
 {: .challenge}
 
-## Problems with Spreadsheets
+### Problems with Spreadsheets
 
 Spreadsheets are good for data entry, but in reality we tend to
 use spreadsheet programs for much more than data entry. We use them
@@ -126,7 +126,7 @@ command-line based statistics program like R or SAS, it’s practically
 impossible to apply a calculation to one observation in your
 dataset but not another unless you’re doing it on purpose.
 
-## Using Spreadsheets for Data Entry and Cleaning
+### Using Spreadsheets for Data Entry and Cleaning
 
 However, there are circumstances where you might want to use a spreadsheet
 program to produce “quick and dirty” calculations or figures, and data
@@ -149,7 +149,7 @@ In this lesson we're going to talk about:
 4. Quality control
 5. Exporting data
 
-# Formatting data tables in spreadsheets
+## Formatting data tables in spreadsheets
 
 **Questions**
 
@@ -202,7 +202,7 @@ interfaces) for data entry and data analysis might be different. It is
 important to take this into account, and ideally automate the
 conversion from one to another.
 
-## Keeping track of your analyses
+### Keeping track of your analyses
 
 When you're working with spreadsheets, during data clean up or
 analyses, it's very easy to end up with a spreadsheet that looks very
@@ -232,7 +232,7 @@ post](https://lgatto.github.io/github-intro/) for a quick tutorial or
 @Perez-Riverol:2016 for a more research-oriented use-case.
 
 
-## Structuring data in spreadsheets
+### Structuring data in spreadsheets
 
 The cardinal rules of using spreadsheet programs for data:
 
@@ -323,7 +323,7 @@ with this data and how you would fix it.
 An **excellent reference**, in particular with regard to R scripting
 is the *Tidy Data* paper @Wickham:2014.
 
-# Common Spreadsheet Errors
+## Common Spreadsheet Errors
 
 **Questions**
 
@@ -374,7 +374,7 @@ and analysis.
 - [Using special characters in data](#special)
 - [Inclusion of metadata in data table](#metadata)
 
-## Using multiple tables {#tables}
+### Using multiple tables {#tables}
 
 A common strategy is creating multiple data tables within
 one spreadsheet. This confuses the computer, so don't do this!
@@ -391,7 +391,7 @@ refer to the same sample. This row actually represents four distinct samples
 (sample 1 for each of four different collection dates - May 29th, June 12th, June 19th, and June 26th),
 as well as some calculated summary statistics (an average (avr) and standard error of measurement (SEM)) for two of those samples. Other rows are similarly problematic.
 
-## Using multiple tabs {#tabs}
+### Using multiple tabs {#tabs}
 
 But what about workbook tabs? That seems like an easy way to organize
 data, right? Well, yes and no. When you create extra tabs, you fail to
@@ -428,7 +428,7 @@ headers](https://support.office.com/en-ca/article/Freeze-column-headings-for-eas
 so that they remain visible even when you have a spreadsheet with many
 rows.
 
-## Not filling in zeros {#zeros}
+### Not filling in zeros {#zeros}
 
 It might be that when you're measuring something, it's usually a zero,
 say the number of times a rabbit is observed in the survey. Why bother
@@ -451,7 +451,7 @@ of this, it's very important to record zeros as zeros and truly
 missing data as nulls.
 
 
-## Using problematic null values {#null}
+### Using problematic null values {#null}
 
 **Example**: using -999 or other numerical values (or zero) to
   represent missing data.
@@ -487,7 +487,7 @@ for different software applications in their article:
 
 ![](../fig/3_white_table_1.jpg)
 
-## Using formatting to convey information {#formatting}
+### Using formatting to convey information {#formatting}
 
 **Example**: highlighting cells, rows or columns that should be
   excluded from an analysis, leaving blank rows to indicate
@@ -501,7 +501,7 @@ for different software applications in their article:
 ![](../fig/good_formatting.png)
 
 
-## Using formatting to make the data sheet look pretty {#formatting_pretty}
+### Using formatting to make the data sheet look pretty {#formatting_pretty}
 
 **Example**: merging cells.
 
@@ -512,7 +512,7 @@ by statistics software. Consider restructuring your data in such a way
 that you will not need to merge cells to organize your data.
 
 
-## Placing comments or units in cells {#units}
+### Placing comments or units in cells {#units}
 
 Most analysis software can't see Excel or LibreOffice comments, and
 would be confused by comments placed within your data cells. As
@@ -523,7 +523,7 @@ unit, but if for some reason they aren’t, create another field and
 specify the units the cell is in.
 
 
-## Entering more than one piece of information in a cell {#info}
+### Entering more than one piece of information in a cell {#info}
 
 **Example**: Recording ABO and Rhesus groups in one cell, such as A+,
 B+, A-, ...
@@ -534,7 +534,7 @@ you need both these measurements, design your data sheet to include
 this information. For example, include one column the ABO group and
 one for the Rhesus group.
 
-## Using problematic field names {#field_name}
+### Using problematic field names {#field_name}
 
 Choose descriptive field names, but be careful not to include spaces,
 numbers, or special characters of any kind. Spaces can be
@@ -562,7 +562,7 @@ confusion and enables others to readily interpret your fields.
 | Observation_01  | first_observation | 1st Obs |
 
 
-## Using special characters in data {#special}
+### Using special characters in data {#special}
 
 **Example**: You treat your spreadsheet program as a word processor
 when writing notes, for example copying data directly from Word or
@@ -582,7 +582,7 @@ tabs, and vertical tabs.  In other words, treat a text cell as if it
 were a simple web form that can only contain text and spaces.
 
 
-## Inclusion of metadata in data table {#metadata}
+### Inclusion of metadata in data table {#metadata}
 
 **Example**: You add a legend at the top or bottom of your data table
   explaining column meaning, units, exceptions, etc.
@@ -630,7 +630,7 @@ Attribution 4.0 International
 License](https://creativecommons.org/licenses/by/4.0/).)
 
 
-# Exporting data
+## Exporting data
 
 **Question**
 
@@ -720,7 +720,7 @@ different worksheets in the `xls` documents.
 - Is there really a good reason why `csv` (or similar) is not
   adequate?
 
-## Caveats on commas
+### Caveats on commas
 
 In some datasets, the data values themselves may include commas
 (,). In that case, the software which you use (including Excel) will
@@ -802,7 +802,7 @@ Python and R lessons will give you the basis for developing skills to
 build relevant scripts.
 
 
-# Summary
+## Summary
 
 ```{r analysis, results='asis', fig.margin=TRUE, fig.cap="A typical data analysis workflow.", fig.width=7, fig.height=4, echo=FALSE, purl=FALSE}
 knitr::include_graphics("../fig/analysis.png")

--- a/_episodes_rmd/20-r-rstudio.Rmd
+++ b/_episodes_rmd/20-r-rstudio.Rmd
@@ -18,7 +18,7 @@ keypoints:
 source("../bin/chunk-options.R")
 ```
 
-# What is R? What is RStudio?
+## What is R? What is RStudio?
 
 The term [R](https://www.r-project.org/) is used to refer to both the
 *programming language*, the *environment for statistical computing*
@@ -39,9 +39,9 @@ Sheet](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf)
 provides much more information that will be covered here, but can be
 useful to learn keyboard shortcuts and discover new features.
 
-# Why learn R?
+## Why learn R?
 
-## R does not involve lots of pointing and clicking, and that's a good thing
+### R does not involve lots of pointing and clicking, and that's a good thing
 
 The learning curve might be steeper than with other software, but with
 R, the results of your analysis do not rely on remembering a
@@ -59,7 +59,7 @@ Working with scripts forces you to have a deeper understanding of what
 you are doing, and facilitates your learning and comprehension of the
 methods you use.
 
-## R code is great for reproducibility
+### R code is great for reproducibility
 
 Reproducibility means that someone else (including your future self) can
 obtain the same results from the same dataset when using the same
@@ -74,7 +74,7 @@ An increasing number of journals and funding agencies expect analyses
 to be reproducible, so knowing R will give you an edge with these
 requirements.
 
-## R is interdisciplinary and extensible
+### R is interdisciplinary and extensible
 
 With 10000+ packages[^whatarepkgs] that can be installed to extend its
 capabilities, R provides a framework that allows you to combine
@@ -90,7 +90,7 @@ genetics, and a lot more.
 knitr::include_graphics("../fig/cran.png")
 ```
 
-## R works on data of all shapes and sizes
+### R works on data of all shapes and sizes
 
 The skills you learn with R scale easily with the size of your
 dataset. Whether your dataset has hundreds or millions of lines, it
@@ -104,14 +104,14 @@ R can connect to spreadsheets, databases, and many other data formats,
 on your computer or on the web.
 
 
-## R produces high-quality graphics
+### R produces high-quality graphics
 
 The plotting functionalities in R are extensive, and allow you to adjust
 any aspect of your graph to convey most effectively the message from
 your data.
 
 
-## R has a large and welcoming community
+### R has a large and welcoming community
 
 Thousands of people use R daily. Many of them are willing to help you
 through mailing lists and websites such as [Stack
@@ -120,13 +120,13 @@ community](https://community.rstudio.com/). These broad user community
 extends to specialised areas such as bioinformatics.
 
 
-## Not only is R free, but it is also open-source and cross-platform
+### Not only is R free, but it is also open-source and cross-platform
 
 Anyone can inspect the source code to see how R works. Because of this
 transparency, there is less chance for mistakes, and if you (or
 someone else) find some, you can report and fix bugs.
 
-# Knowing your way around RStudio
+## Knowing your way around RStudio
 
 Let's start by learning about [RStudio](https://www.rstudio.com/),
 which is an Integrated Development Environment (IDE) for working with
@@ -165,7 +165,7 @@ many shortcuts, **autocompletion**, and **highlighting** for the major
 file types you use while developing in R, RStudio will make typing
 easier and less error-prone.
 
-# Getting set up
+## Getting set up
 
 It is good practice to keep a set of related data, analyses, and text
 self-contained in a single folder, called the **working
@@ -211,7 +211,7 @@ going to set UTF-8 by default:
 knitr::include_graphics("../fig/utf8.png")
 ```
 
-## Organizing your working directory
+### Organizing your working directory
 
 Using a consistent folder structure across your projects will help keep things
 organized, and will also make it easy to find/file things in the future. This
@@ -308,7 +308,7 @@ project[^futureself] to
     run.
 
 
-## The working directory
+### The working directory
 
 The working directory is an important concept to understand. It is the
 place from where R will be looking for and saving the files. When you
@@ -345,7 +345,7 @@ If we were in the `data` directory, we would use the relative path
 `../fig_output/fig1.pdf` or the same absolute path
 `/home/user/bioc-intro/fig_output/fig1.pdf`.
 
-# Interacting with R
+## Interacting with R
 
 The basis of programming is that we write down instructions for the
 computer to follow, and then we tell the computer to follow those
@@ -404,7 +404,7 @@ window and press `Esc`; this will cancel the incomplete command and
 return you to the `>` prompt.
 
 
-# How to learn more during and after the course?
+## How to learn more during and after the course?
 
 The material we cover during this course will give you an initial
 taste of how you can use R to analyse data for your own
@@ -425,9 +425,9 @@ suit your purpose might make it easier for you to get started.
 knitr::include_graphics("../fig/kitten-try-things.jpg")
 ```
 
-# Seeking help
+## Seeking help
 
-## Use the built-in RStudio help interface to search for more information on R functions
+### Use the built-in RStudio help interface to search for more information on R functions
 
 ```{r rstudiohelp, fig.cap="RStudio help interface.", results='markup', echo=FALSE, purl=FALSE, out.width='70%', fig.align='center'}
 knitr::include_graphics("../fig/rstudiohelp.png")
@@ -440,7 +440,7 @@ panel of RStudio. As seen in the screenshot, by typing the word
 might be interested in. The description is then shown in the display
 window.
 
-## I know the name of the function I want to use, but I'm not sure how to use it
+### I know the name of the function I want to use, but I'm not sure how to use it
 
 If you need help with a specific function, let's say `barplot()`, you
 can type:
@@ -455,7 +455,7 @@ If you just need to remind yourself of the names of the arguments, you can use:
 args(lm)
 ```
 
-## I want to use a function that does X, there must be a function for it but I don't know which one...
+### I want to use a function that does X, there must be a function for it but I don't know which one...
 
 If you are looking for a function to do a particular task, you can use the
 `help.search()` function, which is called by the double question mark `??`.
@@ -474,7 +474,7 @@ Finally, a generic Google or internet search "R \<task\>" will often either send
 you to the appropriate package documentation or a helpful forum where someone
 else has already asked your question.
 
-## I am stuck... I get an error message that I don't understand
+### I am stuck... I get an error message that I don't understand
 
 Start by googling the error message. However, this doesn't always work very well
 because often, package developers rely on the error catching provided by R. You
@@ -560,7 +560,7 @@ to understand your problem.
 sessionInfo()
 ```
 
-## Where to ask for help?
+### Where to ask for help?
 
 * The person sitting next to you during the course. Don't hesitate to
   talk to your neighbour during the workshop, compare your answers,
@@ -593,7 +593,7 @@ sessionInfo()
   phylogenetics, etc...), the complete list is
   [here](http://www.r-project.org/mail.html).
 
-## More resources
+### More resources
 
 - The [Posting Guide](http://www.r-project.org/posting-guide.html) for
   the R mailing lists.
@@ -614,9 +614,9 @@ sessionInfo()
   recording](https://vimeo.com/208749032)) includes a presentation of
   the reprex package and of its philosophy.
 
-# R packages
+## R packages
 
-## Loading packages
+### Loading packages
 
 As we have seen above, R packages play a fundamental role in R. The
 make use of a package's functionality, assuming it is installed, we
@@ -627,7 +627,7 @@ first need to load it to be able to use it. This is done with the
 library("ggplot2")
 ```
 
-## Installing packages
+### Installing packages
 
 The default package repository is The *Comprehensive R Archive
 Network* (CRAN), and any package that is available on CRAN can be

--- a/_episodes_rmd/23-starting-with-r.Rmd
+++ b/_episodes_rmd/23-starting-with-r.Rmd
@@ -23,7 +23,7 @@ keypoints:
 source("../bin/chunk-options.R")
 ```
 
-# Creating objects in R
+## Creating objects in R
 
 You can get output from R simply by typing math in the console:
 
@@ -55,7 +55,7 @@ keystroke in a PC, while typing <kbd>Option</kbd> + <kbd>-</kbd> (push
 <kbd>Option</kbd> at the same time as the <kbd>-</kbd> key) does the
 same in a Mac.
 
-## Naming variables {-}
+### Naming variables {-}
 
 Objects can be given any name such as `x`, `current_temperature`, or
 `subject_id`. You want your object names to be explicit and not too
@@ -139,7 +139,7 @@ weight_kg <- 100
 {: .challenge}
 
 
-# Comments
+## Comments
 
 The comment character in R is `#`, anything to the right of a `#` in a
 script will be ignored by R. It is useful to leave notes, and
@@ -167,7 +167,7 @@ press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>.
 {: .challenge}
 
 
-# Functions and their arguments
+## Functions and their arguments
 
 Functions are "canned scripts" that automate more complicated sets of commands
 including operations assignments, etc. Many functions are predefined, or can be
@@ -247,7 +247,7 @@ doing. By specifying the name of the arguments you are also safeguarding
 against possible future changes in the function interface, which may 
 potentially add new arguments in between the existing ones. 
 
-# Vectors and data types
+## Vectors and data types
 
 A vector is the most common and basic data type in R, and is pretty much
 the workhorse of R. A vector is composed by a series of values, such as 
@@ -445,7 +445,7 @@ tricky <- c(1, 2, 3, "4")
 ## types are coerced?
 ```
 
-# Subsetting vectors
+## Subsetting vectors
 
 If we want to extract one or several values from a vector, we must
 provide one or several indices in square brackets. For instance:
@@ -479,7 +479,7 @@ molecules[-c(1, 3)] ## all but 1st/3rd ones
 molecules[c(-1, -3)] ## all but 1st/3rd ones
 ```
 
-# Conditional subsetting
+## Conditional subsetting
 
 Another common way of subsetting is by using a logical vector. `TRUE` will
 select the element with the same index, while `FALSE` will not:
@@ -544,7 +544,7 @@ molecules[molecules %in% c("rna", "dna", "metabolite", "peptide", "glycerol")]
 {: .challenge}
 
 
-# Names
+## Names
 
 It is possible to name each element of a vector. The code chunk below
 show a initial vector without any names, how names are set, and
@@ -565,7 +565,7 @@ x[c(1, 3)]
 x[c("A", "C")]
 ```
 
-# Missing data
+## Missing data
 
 As R was designed to analyze datasets, it includes the concept of
 missing data (which is uncommon in other programming
@@ -635,7 +635,7 @@ heights[complete.cases(heights)]
 {: .challenge}
 
 
-# Generating vectors {#sec:genvec}
+## Generating vectors {#sec:genvec}
 
 ```{r, echo = FALSE}
 set.seed(1)
@@ -675,7 +675,7 @@ There are similar constructors for characters and logicals, named
 > {: .solution}
 {: .challenge}
 
-## Replicate elements
+### Replicate elements
 
 The `rep` function allow to repeat a value a certain number of
 times. If we want to initiate a vector of numerics of length 5 with
@@ -715,7 +715,7 @@ rep(c(1, 2, 3), 5)
 > {: .solution}
 {: .challenge}
 
-## Sequence generation
+### Sequence generation
 
 Another very useful function is `seq`, to generate a sequence of
 numbers. For example, to generate a sequence of integers from 1 to 20
@@ -742,7 +742,7 @@ one would use:
 seq(from = 1, to = 20, length.out = 3)
 ```
 
-## Random samples and permutations
+### Random samples and permutations
 
 A last group of useful functions are those that generate random
 data. The first one, `sample`, generates a random permutation of
@@ -815,7 +815,7 @@ sample(1:5, 10, replace = TRUE)
 > {: .solution}
 {: .challenge}
 
-## Drawing samples from a normal distribution
+### Drawing samples from a normal distribution
 
 The last function we are going to see is `rnorm`, that draws a random
 sample from a normal distribution. Two normal distributions of means 0


### PR DESCRIPTION
Fixes #20 by shifting section headings down one level whenever an episode contains `h1`-level headings in the page content. Please check to ensure I did not break your intended page structure anywhere.