### PR TITLE
Fix typo in lessons 1 - 4

### DIFF
--- a/_episodes_rmd/10-data-organisation.Rmd
+++ b/_episodes_rmd/10-data-organisation.Rmd
@@ -468,7 +468,7 @@ before analysis. Other times different null values are used to convey
 different reasons why the data isn't there. This is important
 information to capture, but is in effect using one column to capture
 two pieces of information. Like for [using formatting to convey
-information]((#formatting) it would be good here to create a new
+information](#formatting) it would be good here to create a new
 column like 'data_missing' and use that column to capture the
 different reasons.
 

--- a/_episodes_rmd/23-starting-with-r.Rmd
+++ b/_episodes_rmd/23-starting-with-r.Rmd
@@ -756,7 +756,7 @@ sample(1:10)
 
 Without further arguments, `sample` will return a permutation of all
 elements of the vector. If I want a random sample of a certain size, I
-would set this value as second argument. Below, I sample 5 random
+would set this value as the second argument. Below, I sample 5 random
 letters from the alphabet contained in the pre-defined `letters` vector:
 
 ```{r}


### PR DESCRIPTION
Hello, I've had a read through lessons 1 - 4 and found a few small typos, fixed in this PR.


**FYI -**
- I also noticed that in episode 2, which contains a few references, they are not rendered in the [.html](https://carpentries-incubator.github.io/bioc-intro/10-data-organisation/index.html)