### PR TITLE
improve link text

### DIFF
--- a/_episodes_rmd/30-dplyr.Rmd
+++ b/_episodes_rmd/30-dplyr.Rmd
@@ -923,8 +923,8 @@ rna_mini
 ```
 
 The second table, `annot1`, contains 2 columns, gene and
-gene_description. You can either download
-[annot1.csv](https://raw.githubusercontent.com/carpentries-incubator/bioc-intro/main/_episodes_rmd/data/annot1.csv)
+gene_description. You can either 
+[download annot1.csv](https://raw.githubusercontent.com/carpentries-incubator/bioc-intro/main/_episodes_rmd/data/annot1.csv)
 by clicking on the link and then moving it to the `data/` folder, or
 you can use the R code below to download it directly to the folder.
 
@@ -950,10 +950,9 @@ full_join(rna_mini, annot1)
 
 In real life, gene annotations are sometimes labelled differently.
 
-The [`annot2`] table is exactly the same than `annot1` except that the
+The `annot2` table is exactly the same than `annot1` except that the
 variable containing gene names is labelled differently. Again, either
-download
-[annot2.csv](https://raw.githubusercontent.com/carpentries-incubator/bioc-intro/main/_episodes_rmd/data/annot2.csv)
+[download annot2.csv](https://raw.githubusercontent.com/carpentries-incubator/bioc-intro/main/_episodes_rmd/data/annot2.csv)
 yourself and move it to `data/` or use the R code below.
 
 ```{r, message= FALSE}


### PR DESCRIPTION
make the links to download the `annot1` and `annot2` files more accessible to those visiting the lesson with a  screen reader.