### PR TITLE
fix overlapping solutions in learner setup

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,15 @@
 permalink: index.html
 site: sandpaper::sandpaper_site
 ---
+## About this course
 
+::::::::::::::::::::::::::::::::::::::::::  prereq
+
+## Prerequisites
+
+- Familiarity with tabular data and spreadsheets.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
 

--- a/index.md
+++ b/index.md
@@ -3,19 +3,6 @@ permalink: index.html
 site: sandpaper::sandpaper_site
 ---
 
-<!-- this is an html comment -->
-
-{% comment %} This is a comment in Liquid {% endcomment %}
-
-## About this course
-
-::::::::::::::::::::::::::::::::::::::::::  prereq
-
-## Prerequisites
-
-- Familiarity with tabular data and spreadsheets.
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -20,6 +20,8 @@ title: Setup
 
 ### You are running Windows
 
+<br>
+
 :::::::::::::::  solution
 
 ## If you already have R and RStudio installed
@@ -67,6 +69,8 @@ title: Setup
 :::::::::::::::::::::::::
 
 ### You are running macOS
+
+<br>
 
 :::::::::::::::  solution
 
@@ -118,6 +122,8 @@ title: Setup
 :::::::::::::::::::::::::
 
 ### You are running Linux
+
+<br>
 
 :::::::::::::::  solution
 


### PR DESCRIPTION
In the learner's view setup of the new workbench version the solutions were printed on top of each other. This branch fixes this by adding line breaks before each solution section. This has been solved similarly in the setup of the [Rewrite-R-ecology-lesson](https://github.com/MCMaurer/Rewrite-R-ecology-lesson/blob/main/learners/setup.md).  The template text from `index.md` referring to how comments are written in liquid and prerequisites were also removed. Or should prerequisites be kept? 