### PR TITLE
Update reference.md

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -1,5 +1,5 @@
 ---
-{}
+title: Reference
 ---
 
 ## Glossary


### PR DESCRIPTION
The Reference page was not showing up nicely in the _More_ dropdown menu because the Markdown source was missing a `title` in the YAML header. This PR defines that title, which should make the it appear in the dropdown.

![Screenshot 2025-02-18 at 14 13 04](https://github.com/user-attachments/assets/117f91f3-8f05-407c-94b9-e891befddc94)
