### PR TITLE
Create crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,41 @@
+preserve_hierarchy: true
+
+files:
+  - source: /episodes/*.Rmd
+    dest: /episodes/%file_name%.md
+    type: md
+    translation: /locale/%two_letters_code%/episodes/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /episodes/*.md
+    translation: /locale/%two_letters_code%/episodes/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /instructors/*.md
+    translation: /locale/%two_letters_code%/instructors/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /learners/*.md
+    translation: /locale/%two_letters_code%/learners/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /profiles/*.md
+    translation: /locale/%two_letters_code%/profiles/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /CODE_OF_CONDUCT.md
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /config.yaml
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /CONTRIBUTING.md
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /LICENSE.md
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /README.md
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /index.md
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /links.md
+    translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved


### PR DESCRIPTION
@csoneson @lgatto 
Crowdin does not support rendering Rmd files.
We need to use this YAML configuration to make Crowdin recognize Rmd files as Markdown.